### PR TITLE
release callbackobject after release eventhandler. Other wise may be …

### DIFF
--- a/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/MediaPlayerImpl.cs
+++ b/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/MediaPlayerImpl.cs
@@ -143,14 +143,6 @@ namespace Agora.Rtc
         {
             if (_mediaPlayerEventHandlerHandle.handle == IntPtr.Zero) return;
 
-            MediaPlayerSourceObserverNative.ClearSourceObserver();
-
-#if UNITY_EDITOR_WIN || UNITY_EDITOR_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_ANDROID 
-            MediaPlayerSourceObserverNative.CallbackObject = null;
-            if (_callbackObject != null) _callbackObject.Release();
-            _callbackObject = null;
-#endif
-
             IntPtr[] arrayPtr = new IntPtr[] { _mediaPlayerEventHandlerHandle.handle };
             var nRet = AgoraRtcNative.CallIrisApiWithArgs(_irisApiEngine, AgoraApiType.FUNC_MEDIAPLAYER_UNREGISTERPLAYERSOURCEOBSERVER,
                 "{}", 2,
@@ -163,6 +155,17 @@ namespace Agora.Rtc
             }
 
             AgoraUtil.FreeEventHandlerHandle(ref _mediaPlayerEventHandlerHandle);
+
+
+            ///You must release callbackObject after you release eventhandler.
+            ///Otherwise may be agcallback and unity main loop can will both access callback object. make crash
+            MediaPlayerSourceObserverNative.ClearSourceObserver();
+
+#if UNITY_EDITOR_WIN || UNITY_EDITOR_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_ANDROID 
+            MediaPlayerSourceObserverNative.CallbackObject = null;
+            if (_callbackObject != null) _callbackObject.Release();
+            _callbackObject = null;
+#endif
 
         }
 

--- a/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/MediaRecorderImpl.cs
+++ b/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/MediaRecorderImpl.cs
@@ -119,6 +119,10 @@ namespace Agora.Rtc
             }
             _mediaRecorderEventHandlerHandles.Clear();
 
+
+
+            ///You must release callbackObject after you release eventhandler.
+            ///Otherwise may be agcallback and unity main loop can will both access callback object. make crash
 #if UNITY_EDITOR_WIN || UNITY_EDITOR_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_ANDROID
             if (_callbackObject != null)
             {

--- a/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/MusicContentCenterImpl.cs
+++ b/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/MusicContentCenterImpl.cs
@@ -97,6 +97,8 @@ namespace Agora.Rtc
             AgoraUtil.FreeEventHandlerHandle(ref _musicContentCenterHandlerHandle);
 
 
+            ///You must release callbackObject after you release eventhandler.
+            ///Otherwise may be agcallback and unity main loop can will both access callback object. make crash
 #if UNITY_EDITOR_WIN || UNITY_EDITOR_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_ANDROID
             MusicContentCenterEventHandlerNative.CallbackObject = null;
             if (_callbackObject != null) _callbackObject.Release();

--- a/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/RtcEngineImpl.cs
+++ b/Agora-C_Sharp-RTC-SDK/Code/Rtc/Impl/Private/Impl/RtcEngineImpl.cs
@@ -124,9 +124,12 @@ namespace Agora.Rtc
             Release(sync);
 
             ReleaseEventHandler();
-            //You must free cdn event handle after you release engine.
-            //Because when engine releasing. will call some Cdn event function.We need keep cdn event function ptr alive
+            ///You must free cdn event handle after you release engine.
+            ///Because when engine releasing. will call some Cdn event function.We need keep cdn event function ptr alive
             ReleaseDirectCdnStreamingEventHandle();
+
+            ///You must release callbackObject after you release eventhandler.
+            ///Otherwise may be agcallback and unity main loop can will both access callback object. make crash
 
 #if UNITY_EDITOR_WIN || UNITY_EDITOR_OSX || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_ANDROID
             if (_callbackObject != null)


### PR DESCRIPTION
…Agcallback and unity main loop will both access callbackobject, make crash